### PR TITLE
feat: Added user inventories

### DIFF
--- a/server/constants.py
+++ b/server/constants.py
@@ -1,0 +1,27 @@
+from models import ItemType, NodeType
+
+
+NODE_TYPE_WEIGHTS = {
+    NodeType.TREE: 100,
+    NodeType.ROCK_BASIC: 40,
+    NodeType.ROCK_COPPER: 25,
+    NodeType.ROCK_IRON: 15,
+}
+
+
+NODE_ITEM_DROPS = {
+    NodeType.TREE: [
+        (ItemType.BASIC_WOOD, (2, 5)),
+    ],
+    NodeType.ROCK_BASIC: [
+        (ItemType.BASIC_STONE, (2, 4)),
+    ],
+    NodeType.ROCK_COPPER: [
+        (ItemType.BASIC_STONE, (1, 3)),
+        (ItemType.COPPER_ORE, (1, 2)),
+    ],
+    NodeType.ROCK_IRON: [
+        (ItemType.BASIC_STONE, (1, 3)),
+        (ItemType.IRON_ORE, (1, 2)),
+    ],
+}

--- a/server/db/items.py
+++ b/server/db/items.py
@@ -19,22 +19,34 @@ async def get_items_of_user(conn: Connection, user_id: int) -> list[Item]:
     return [Item.model_validate(dict(row)) for row in rows]
 
 
-async def insert_item(
+async def insert_or_add_item(
     conn: Connection,
     user_id: int,
     item_type: str,
     item_count: Optional[int],
     metadata: Optional[dict],
 ) -> Optional[int]:
-    """Inserts a new user item into the database and
-    returns its ID.
+    """ Inserts or updates a user item in the database.
+    If item is non-stackable, inserts a new row.
+    If item is stackable, adds to the existing count or creates a new row.
+    Returns the ID of the affected row.
     """
-    query = """
-    INSERT INTO user_items (user_id, item_type, item_count, metadata)
-    VALUES ($1, $2, $3, $4)
-    RETURNING id;
-    """
-    res = await conn.fetchval(
-        query, user_id, item_type, item_count, metadata
-    )
+    if item_count is None:  # Non-stackable
+        query = """
+        INSERT INTO user_items (user_id, item_type, item_count, metadata)
+        VALUES ($1, $2, NULL, $3)
+        RETURNING id;
+        """
+        res = await conn.fetchval(query, user_id, item_type, metadata)
+    else:  # Stackable
+        query = """
+        INSERT INTO user_items (user_id, item_type, item_count, metadata)
+        VALUES ($1, $2, $3, NULL)
+        ON CONFLICT (user_id, item_type) WHERE item_count IS NOT NULL
+        DO UPDATE
+        SET item_count = user_items.item_count + EXCLUDED.item_count
+        RETURNING id;
+        """
+        res = await conn.fetchval(query, user_id, item_type, item_count)
+    
     return res

--- a/server/db/items.py
+++ b/server/db/items.py
@@ -2,11 +2,6 @@ from typing import Optional
 from asyncpg import Connection
 from models import Item
 
-    # id: int
-    # user_id: int = Field(..., alias="userId")
-    # item_type: str = Field(..., alias="itemType")
-    # item_count: Optional[str] = Field(..., alias="itemCount")
-    # metadata: Optional[dict]
 
 async def get_items_of_user(conn: Connection, user_id: int) -> list[Item]:
     """Returns all the items associated with a given user."""
@@ -24,14 +19,14 @@ async def get_items_of_user(conn: Connection, user_id: int) -> list[Item]:
     return [Item.model_validate(dict(row)) for row in rows]
 
 
-async def insert_resource_node(
+async def insert_item(
     conn: Connection,
     user_id: int,
     item_type: str,
     item_count: Optional[int],
     metadata: Optional[dict],
 ) -> Optional[int]:
-    """Inserts a new resource node into the database and
+    """Inserts a new user item into the database and
     returns its ID.
     """
     query = """

--- a/server/db/items.py
+++ b/server/db/items.py
@@ -1,6 +1,6 @@
 from typing import Optional
 from asyncpg import Connection
-from models import Item
+from models import Item, ItemType
 
 
 async def get_items_of_user(conn: Connection, user_id: int) -> list[Item]:
@@ -22,9 +22,9 @@ async def get_items_of_user(conn: Connection, user_id: int) -> list[Item]:
 async def insert_or_add_item(
     conn: Connection,
     user_id: int,
-    item_type: str,
+    item_type: ItemType,
     item_count: Optional[int],
-    metadata: Optional[dict],
+    metadata: Optional[dict] = None,
 ) -> Optional[int]:
     """ Inserts or updates a user item in the database.
     If item is non-stackable, inserts a new row.

--- a/server/db/items.py
+++ b/server/db/items.py
@@ -26,27 +26,39 @@ async def insert_or_add_item(
     item_count: Optional[int],
     metadata: Optional[dict] = None,
 ) -> Optional[int]:
-    """ Inserts or updates a user item in the database.
+    """Inserts or updates a user item in the database.
     If item is non-stackable, inserts a new row.
     If item is stackable, adds to the existing count or creates a new row.
     Returns the ID of the affected row.
     """
-    if item_count is None:  # Non-stackable
-        query = """
-        INSERT INTO user_items (user_id, item_type, item_count, metadata)
-        VALUES ($1, $2, NULL, $3)
-        RETURNING id;
-        """
-        res = await conn.fetchval(query, user_id, item_type, metadata)
-    else:  # Stackable
-        query = """
-        INSERT INTO user_items (user_id, item_type, item_count, metadata)
-        VALUES ($1, $2, $3, NULL)
-        ON CONFLICT (user_id, item_type) WHERE item_count IS NOT NULL
-        DO UPDATE
-        SET item_count = user_items.item_count + EXCLUDED.item_count
-        RETURNING id;
-        """
-        res = await conn.fetchval(query, user_id, item_type, item_count)
-    
-    return res
+    ids = await insert_or_add_items(
+        conn, user_id, [(item_type, item_count, metadata)]
+    )
+    return ids[0]
+
+
+async def insert_or_add_items(
+    conn: Connection,
+    user_id: int,
+    # List of (item_type, item_count, metadata)
+    items: list[tuple[ItemType, Optional[int], Optional[dict]]],
+) -> list[Optional[int]]:
+    """Inserts or updates multiple user items in the database.
+    If the item is non-stackable, inserts a new row.
+    If the item is stackable, adds to the existing count or creates a new row.
+    Returns a list of IDs of the affected rows.
+    """
+    query = """
+    INSERT INTO user_items (user_id, item_type, item_count, metadata)
+    VALUES ($1, $2, $3, $4)
+    ON CONFLICT (user_id, item_type) WHERE item_count IS NOT NULL
+    DO UPDATE
+    SET item_count = user_items.item_count + EXCLUDED.item_count
+    RETURNING id;
+    """
+    # Prepare the values for bulk insert
+    insert_values = [(user_id, item_type, item_count, metadata)
+                     for item_type, item_count, metadata in items]
+    rows = await conn.fetchmany(query, insert_values)
+    ids = [row["id"] for row in rows]
+    return ids

--- a/server/db/items.py
+++ b/server/db/items.py
@@ -3,8 +3,8 @@ from asyncpg import Connection
 from models import Item, ItemType
 
 
-async def get_items_of_user(conn: Connection, user_id: int) -> list[Item]:
-    """Returns all the items associated with a given user."""
+async def get_user_inventory(conn: Connection, user_id: int) -> list[Item]:
+    """Returns all the items in a given user's inventory."""
     query = """
     SELECT
         id,

--- a/server/db/items.py
+++ b/server/db/items.py
@@ -1,0 +1,45 @@
+from typing import Optional
+from asyncpg import Connection
+from models import Item
+
+    # id: int
+    # user_id: int = Field(..., alias="userId")
+    # item_type: str = Field(..., alias="itemType")
+    # item_count: Optional[str] = Field(..., alias="itemCount")
+    # metadata: Optional[dict]
+
+async def get_items_of_user(conn: Connection, user_id: int) -> list[Item]:
+    """Returns all the items associated with a given user."""
+    query = """
+    SELECT
+        id,
+        user_id,
+        item_type,
+        item_count,
+        metadata
+    FROM user_items
+    WHERE user_id = $1;
+    """
+    rows = await conn.fetch(query, user_id)
+    return [Item.model_validate(dict(row)) for row in rows]
+
+
+async def insert_resource_node(
+    conn: Connection,
+    user_id: int,
+    item_type: str,
+    item_count: Optional[int],
+    metadata: Optional[dict],
+) -> Optional[int]:
+    """Inserts a new resource node into the database and
+    returns its ID.
+    """
+    query = """
+    INSERT INTO user_items (user_id, item_type, item_count, metadata)
+    VALUES ($1, $2, $3, $4)
+    RETURNING id;
+    """
+    res = await conn.fetchval(
+        query, user_id, item_type, item_count, metadata
+    )
+    return res

--- a/server/db/schema.sql
+++ b/server/db/schema.sql
@@ -49,3 +49,20 @@ CREATE INDEX idx_location ON resource_nodes USING GIST(location);
 
 -- Add a user_id index to optimize user based queries
 CREATE INDEX idx_user_id ON resource_nodes (user_id);
+
+CREATE TABLE user_items (
+    id SERIAL PRIMARY KEY,
+    user_id INT NOT NULL
+        REFERENCES users(id)
+        ON DELETE CASCADE,
+    item_type VARCHAR(50) NOT NULL,
+    item_count INT CHECK (item_count >= 1), -- Only for items with count
+    metadata JSONB, -- Only for nonstackable items
+    CHECK (
+        (item_count IS NULL AND metadata IS NOT NULL) OR -- Nonstackable items
+        (item_count IS NOT NULL AND metadata IS NULL)    -- Items with count
+    )
+);
+
+-- Add a user_id index to optimize user based queries
+CREATE INDEX idx_user_items_user_id ON user_items (user_id);

--- a/server/db/schema.sql
+++ b/server/db/schema.sql
@@ -66,3 +66,8 @@ CREATE TABLE user_items (
 
 -- Add a user_id index to optimize user based queries
 CREATE INDEX idx_user_items_user_id ON user_items (user_id);
+
+-- Stackable items only have one entry per type (per user)
+CREATE UNIQUE INDEX unique_user_item_type_null_count
+ON user_items (user_id, item_type)
+WHERE item_count IS NOT NULL;

--- a/server/db/schema.sql
+++ b/server/db/schema.sql
@@ -68,6 +68,6 @@ CREATE TABLE user_items (
 CREATE INDEX idx_user_items_user_id ON user_items (user_id);
 
 -- Stackable items only have one entry per type (per user)
-CREATE UNIQUE INDEX unique_user_item_type_null_count
+CREATE UNIQUE INDEX unique_user_item_stackable
 ON user_items (user_id, item_type)
 WHERE item_count IS NOT NULL;

--- a/server/main.py
+++ b/server/main.py
@@ -1,10 +1,14 @@
 from contextlib import asynccontextmanager
-from fastapi import FastAPI
+from asyncpg import Pool
+from fastapi import FastAPI, Request
 from db.connection import get_db_pool
+from db.items import get_items_of_user, insert_or_add_item
 from middleware import init_middleware
+from models import NodeType
 from routes.auth import router as auth_router
 from routes.nodes import router as nodes_router
 from routes.session import router as session_router
+from utils.nodes import get_node_item_drops
 
 
 @asynccontextmanager
@@ -28,3 +32,14 @@ app.include_router(session_router, prefix="/session", tags=["session"])
 @app.get("/")
 async def get_root():
     return {"message": "This is an API"}
+
+
+@app.get("/item-test")
+async def item_test(request: Request, user_id: int):
+    pool: Pool = request.app.state.db_pool
+    async with pool.acquire() as conn:
+        new_items = get_node_item_drops(NodeType.ROCK_IRON)
+        for item_type, count in new_items:
+            await insert_or_add_item(conn, user_id, item_type, count)
+        user_items = await get_items_of_user(conn, user_id)
+    return {"newItems": new_items, "userItems": user_items}

--- a/server/main.py
+++ b/server/main.py
@@ -24,6 +24,7 @@ app.include_router(auth_router, prefix="/auth", tags=["auth"])
 app.include_router(nodes_router, prefix="/nodes", tags=["nodes"])
 app.include_router(session_router, prefix="/session", tags=["session"])
 
+
 @app.get("/")
 async def get_root():
     return {"message": "This is an API"}

--- a/server/main.py
+++ b/server/main.py
@@ -2,7 +2,7 @@ from contextlib import asynccontextmanager
 from asyncpg import Pool
 from fastapi import FastAPI, Request
 from db.connection import get_db_pool
-from db.items import get_user_inventory, insert_or_add_item
+from db.items import get_user_inventory, insert_or_add_item, insert_or_add_items
 from middleware import init_middleware
 from models import NodeType
 from routes.auth import router as auth_router
@@ -39,7 +39,10 @@ async def item_test(request: Request, user_id: int):
     pool: Pool = request.app.state.db_pool
     async with pool.acquire() as conn:
         new_items = get_node_item_drops(NodeType.ROCK_IRON)
-        for item_type, count in new_items:
-            await insert_or_add_item(conn, user_id, item_type, count)
+        await insert_or_add_items(
+            conn, user_id,
+            [(item_type, item_count, None)
+             for item_type, item_count in new_items]
+        )
         user_items = await get_user_inventory(conn, user_id)
     return {"newItems": new_items, "userItems": user_items}

--- a/server/main.py
+++ b/server/main.py
@@ -2,7 +2,7 @@ from contextlib import asynccontextmanager
 from asyncpg import Pool
 from fastapi import FastAPI, Request
 from db.connection import get_db_pool
-from db.items import get_items_of_user, insert_or_add_item
+from db.items import get_user_inventory, insert_or_add_item
 from middleware import init_middleware
 from models import NodeType
 from routes.auth import router as auth_router
@@ -41,5 +41,5 @@ async def item_test(request: Request, user_id: int):
         new_items = get_node_item_drops(NodeType.ROCK_IRON)
         for item_type, count in new_items:
             await insert_or_add_item(conn, user_id, item_type, count)
-        user_items = await get_items_of_user(conn, user_id)
+        user_items = await get_user_inventory(conn, user_id)
     return {"newItems": new_items, "userItems": user_items}

--- a/server/models.py
+++ b/server/models.py
@@ -56,11 +56,18 @@ class GameSession(BaseModel):
         populate_by_name = True
 
 
+class ItemType(str, Enum):
+    BASIC_WOOD = "basicWood"
+    BASIC_STONE = "basicStone"
+    COPPER_ORE = "copperOre"
+    IRON_ORE = "ironOre"
+
+
 class Item(BaseModel):
     id: int
     user_id: int = Field(..., alias="userId")
-    item_type: str = Field(..., alias="itemType")
-    item_count: Optional[str] = Field(..., alias="itemCount")
+    item_type: ItemType = Field(..., alias="itemType")
+    item_count: Optional[int] = Field(..., alias="itemCount")
     metadata: Optional[dict]
 
     class Config:

--- a/server/models.py
+++ b/server/models.py
@@ -16,14 +16,6 @@ class NodeType(str, Enum):
     ROCK_IRON = "rockIron"
 
 
-NODE_TYPE_WEIGHTS = {
-    NodeType.TREE: 100,
-    NodeType.ROCK_BASIC: 40,
-    NodeType.ROCK_COPPER: 25,
-    NodeType.ROCK_IRON: 15,
-}
-
-
 class ResourceNode(BaseModel):
     id: int
     user_id: int = Field(..., alias="userId")

--- a/server/models.py
+++ b/server/models.py
@@ -54,3 +54,14 @@ class GameSession(BaseModel):
 
     class Config:
         populate_by_name = True
+
+
+class Item(BaseModel):
+    id: int
+    user_id: int = Field(..., alias="userId")
+    item_type: str = Field(..., alias="itemType")
+    item_count: Optional[str] = Field(..., alias="itemCount")
+    metadata: Optional[dict]
+
+    class Config:
+        populate_by_name = True

--- a/server/routes/handlers/get_inventory.py
+++ b/server/routes/handlers/get_inventory.py
@@ -1,0 +1,16 @@
+from asyncpg import Pool
+from fastapi import WebSocket
+from db.items import get_user_inventory
+from models import User
+
+
+async def handle_get_inventory(websocket: WebSocket, user: User) -> None:
+    pool: Pool = websocket.app.state.db_pool
+    async with pool.acquire() as conn:
+        items = await get_user_inventory(conn, user.id)
+    item_jsons = [item.model_dump(by_alias=True) for item in items]
+    response = {
+        "type": "inventory",
+        "data": item_jsons,
+    }
+    await websocket.send_json(response)

--- a/server/routes/nodes.py
+++ b/server/routes/nodes.py
@@ -1,4 +1,3 @@
-import random
 from asyncpg import Pool
 from fastapi import APIRouter, Request
 from pydantic import BaseModel, Field
@@ -7,15 +6,9 @@ from db.nodes import (
     get_resource_nodes_of_user,
     insert_resource_node,
 )
-from models import NODE_TYPE_WEIGHTS, Coords, NodeType, ResourceNode
+from models import Coords, NodeType, ResourceNode
 
 router = APIRouter()
-
-
-def get_random_node_type() -> NodeType:
-    types = list(NODE_TYPE_WEIGHTS.keys())
-    weights = list(NODE_TYPE_WEIGHTS.values())
-    return random.choices(types, weights=weights, k=1)[0]
 
 
 @router.get("")

--- a/server/routes/session.py
+++ b/server/routes/session.py
@@ -5,6 +5,7 @@ from fastapi import APIRouter, WebSocket, WebSocketDisconnect
 from db.auth import get_auth_session_id, get_user_from_auth_session
 from db.session import get_game_session, remove_game_session
 from routes.handlers.get_resource_nodes import handle_get_resource_nodes
+from routes.handlers.get_inventory import handle_get_inventory
 from routes.handlers.location import handle_location_update
 from utils.hashing import hash_sha256
 from utils.websocket_manager import WebSocketManager
@@ -91,6 +92,10 @@ async def websocket_endpoint(websocket: WebSocket) -> None:
             elif message_type == "get_resource_nodes":
                 await handle_get_resource_nodes(websocket, user)
                 print("Sent resource nodes to "
+                      f"{user.username} ({user.id})")
+            elif message_type == "get_inventory":
+                await handle_get_inventory(websocket, user)
+                print("Sent user inventory to "
                       f"{user.username} ({user.id})")
             else:
                 print(f"Unknown message type {message_type} from "

--- a/server/utils/nodes.py
+++ b/server/utils/nodes.py
@@ -1,0 +1,9 @@
+import random
+from constants import NODE_TYPE_WEIGHTS
+from models import NodeType
+
+
+def get_random_node_type() -> NodeType:
+    types = list(NODE_TYPE_WEIGHTS.keys())
+    weights = list(NODE_TYPE_WEIGHTS.values())
+    return random.choices(types, weights=weights, k=1)[0]

--- a/server/utils/nodes.py
+++ b/server/utils/nodes.py
@@ -1,9 +1,17 @@
 import random
-from constants import NODE_TYPE_WEIGHTS
-from models import NodeType
+from constants import NODE_ITEM_DROPS, NODE_TYPE_WEIGHTS
+from models import ItemType, NodeType
 
 
 def get_random_node_type() -> NodeType:
     types = list(NODE_TYPE_WEIGHTS.keys())
     weights = list(NODE_TYPE_WEIGHTS.values())
     return random.choices(types, weights=weights, k=1)[0]
+
+
+def get_node_item_drops(node_type: NodeType) -> list[tuple[ItemType, int]]:
+    drops = []
+    for item_type, bounds in NODE_ITEM_DROPS[node_type]:
+        count = random.randint(*bounds)
+        drops.append((item_type, count))
+    return drops

--- a/shared/item_types.json
+++ b/shared/item_types.json
@@ -1,0 +1,22 @@
+[
+  {
+    "name": "basicWood",
+    "type": "resource",
+    "displayName": "Wood"
+  },
+  {
+    "name": "basicStone",
+    "type": "resource",
+    "displayName": "Stone"
+  },
+  {
+    "name": "copperOre",
+    "type": "resource",
+    "displayName": "Copper Ore"
+  },
+  {
+    "name": "ironOre",
+    "type": "resource",
+    "displayName": "Iron Ore"
+  }
+]


### PR DESCRIPTION
This PR adds user inventories through the `user_items` table in the database schema. The implementation is quite naive but should work for all items at the moment. I also added some backend functions to add items to and fetch a user's inventory. I added a shared \`item_types.json\` file for information that might frequently change (display names, descriptions, etc.).

I still need to hook up the frontend to allow viewing of the user's inventory and collecting nodes to obtain said items in the first place. Server-initiated node spawning/despawning is also still needed to manage the nodes in a scalable way.